### PR TITLE
Log messages before freeing data

### DIFF
--- a/ngx_http_unzip_module.c
+++ b/ngx_http_unzip_module.c
@@ -200,8 +200,8 @@ static ngx_int_t ngx_http_unzip_handler(ngx_http_request_t *r)
 
     unzipextract_path = malloc(unzip_extract.len+1);
     if (unzipextract_path == NULL) {
-        free(unzipfile_path);
         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "Failed to allocate buffer.");
+        free(unzipfile_path);
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
 
@@ -214,9 +214,9 @@ static ngx_int_t ngx_http_unzip_handler(ngx_http_request_t *r)
 
     /* try to open archive (zip) file */
     if (!(zip_source = zip_open(unzipfile_path, 0, &err))) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "%s : no such archive file.", unzipfile_path);
         free(unzipfile_path);
         free(unzipextract_path);
-        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "%s : no such archive file.", unzipfile_path);
         return NGX_HTTP_NOT_FOUND;
     }
 
@@ -225,19 +225,19 @@ static ngx_int_t ngx_http_unzip_handler(ngx_http_request_t *r)
 
     /* let's check what's the size of a file. return 404 if we can't stat file inside archive */
     if (0 != zip_stat(zip_source, unzipextract_path, 0, &zip_st)) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "no file %s inside %s archive.", unzipextract_path, unzipfile_path);
         free(unzipfile_path);
         free(unzipextract_path);
         zip_close(zip_source);
-        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "no file %s inside %s archive.", unzipextract_path, unzipfile_path);
         return NGX_HTTP_NOT_FOUND;
     }
 
     /* allocate buffer for the file content */
     if (!(zip_content = ngx_palloc(r->pool, zip_st.size))) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "Failed to allocate response buffer memory.");
         free(unzipfile_path);
         free(unzipextract_path);
         zip_close(zip_source);
-        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "Failed to allocate response buffer memory.");
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
 
@@ -246,11 +246,11 @@ static ngx_int_t ngx_http_unzip_handler(ngx_http_request_t *r)
     *  so let's return 500.
     */
     if (!(file_in_zip = zip_fopen(zip_source, unzipextract_path, 0))) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "failed to open %s from %s archive (corrupted?).",
+                unzipextract_path, unzipfile_path);
         free(unzipfile_path);
         free(unzipextract_path);
         zip_close(zip_source);
-        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "failed to open %s from %s archive (corrupted?).",
-                unzipextract_path, unzipfile_path);
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
 
@@ -259,12 +259,12 @@ static ngx_int_t ngx_http_unzip_handler(ngx_http_request_t *r)
     *  we're expecting to get zip_st.size bytes so return 500 if we get something else.
     */
     if (!(zip_read_bytes = zip_fread(file_in_zip, zip_content, zip_st.size)) || zip_read_bytes != zip_st.size) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "couldn't get %d bytes of %s from %s archive (corrupted?).",
+                zip_st.size, unzipextract_path, unzipfile_path);
         free(unzipfile_path);
         free(unzipextract_path);
         zip_fclose(file_in_zip);
         zip_close(zip_source);
-        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "couldn't get %d bytes of %s from %s archive (corrupted?).",
-                zip_st.size, unzipextract_path, unzipfile_path);
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
 


### PR DESCRIPTION
Seems I introduced a bad memory bug myself. I was logging errors using the freed pointers. The following commit fixes it. 

Regards,
